### PR TITLE
Add LED subsystem testing

### DIFF
--- a/src/main/java/frc/robot/commands/SetLightPattern.java
+++ b/src/main/java/frc/robot/commands/SetLightPattern.java
@@ -13,7 +13,7 @@ public class SetLightPattern extends Command {
   public SetLightPattern(LEDSubsystem led, int strip, double pattern) {
     if (strip < -1)
       throw new IllegalArgumentException(
-          "LED configuration commands may ONLY use -1 or higher for strip IDs!");
+          "LED configuration commands may ONLY use -1 (all strips) or higher for strip IDs!");
     ledSystem = led;
     this.pattern = pattern;
   }

--- a/src/main/java/frc/robot/commands/test/LEDTestCommand.java
+++ b/src/main/java/frc/robot/commands/test/LEDTestCommand.java
@@ -1,0 +1,49 @@
+package frc.robot.commands.test;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.led.LEDConstants;
+import frc.robot.subsystems.led.LEDSubsystem;
+
+public class LEDTestCommand extends Command {
+  private LEDSubsystem ledSystem;
+
+  private double currentPattern;
+
+  private int ticker;
+  private final int delay;
+
+  /**
+   * @param led LED subsystem object to use
+   * @param time Time in robot updates to wait between changes (each update is 20ms, so 50 updates is 1 second)
+   */
+  public LEDTestCommand(LEDSubsystem led, int time) {
+    ledSystem = led;
+    delay = time;
+  }
+
+  @Override
+  public void initialize() {
+    currentPattern = LEDConstants.LEDPatterns.BLACK;
+    ticker = 0;
+  }
+
+  @Override
+  public void execute() {
+    if (ticker++ < delay)
+      return;
+
+    //0.02 is the difference between each state, so we go down the list of all possible colors
+    currentPattern -= 0.02;
+    ledSystem.applyPatternToAll(currentPattern);
+  }
+
+  @Override
+  public boolean isFinished() {
+    return currentPattern <= LEDConstants.LEDPatterns.HOT_PINK;
+  }
+
+  @Override
+  public void end(boolean interrupted) {
+    currentPattern = LEDConstants.LEDPatterns.BLACK;
+  }
+}


### PR DESCRIPTION
Hello humans of 8032.  

I have created a command to test my LED subsystem.  

It resides in a special `test`subdirectory of the `commands` folder to isolate it from real commands we use at meets. Hopefully other testing commands will go there as well.  

Adiós.