### PR TITLE
Merge AddressableLED subsystem

### DIFF
--- a/src/main/java/frc/robot/commands/SetAddressableLEDPattern.java
+++ b/src/main/java/frc/robot/commands/SetAddressableLEDPattern.java
@@ -1,0 +1,40 @@
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.LEDPattern;
+import edu.wpi.first.wpilibj2.command.Command;
+
+public class SetAddressableLEDPattern extends Command {
+  private final AddressableLEDSubsystem ledSystem;
+  private final int
+      section; // If this is -1, that means that this command is targeting the whole strip
+  private final LEDPattern pattern;
+
+  /**
+   * @param
+   */
+  public SetAddressableLEDPattern(AddressableLEDSubsystem led, LEDPattern pattern, int section) {
+    this.section = section;
+    this.pattern = pattern;
+    ledSystem = led;
+  }
+
+  public SetAddressableLEDPattern(AddressableLEDSubsystem led, LEDPattern pattern) {
+    this(led, pattern, -1);
+  }
+
+  public void initialize() {}
+
+  public void execute() {
+    if (section < 0) {
+      ledSystem.applyPattern(pattern);
+    } else {
+      ledSystem.applySectionedPattern(pattern, section);
+    }
+  }
+
+  public boolean isFinished() {
+    return true;
+  }
+
+  public void end(boolean interrupted) {}
+}

--- a/src/main/java/frc/robot/subsystems/addressableled/AddressableLEDConstants.java
+++ b/src/main/java/frc/robot/subsystems/addressableled/AddressableLEDConstants.java
@@ -1,0 +1,10 @@
+package frc.robot.subsystems.addressableled;
+
+public class AddressableLEDConstants {
+  private record Range(int low, int high) {}
+
+  // TODO: Implement real values
+  public static final int LED_COUNT = 64;
+  public static final int LED_STRIP_PORT = 0;
+  public static final Range SECTIONS[] = {new Range(0, LED_COUNT)};
+}

--- a/src/main/java/frc/robot/subsystems/addressableled/AddressableLEDSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/addressableled/AddressableLEDSubsystem.java
@@ -1,0 +1,46 @@
+package frc.robot.subsystems.addressableled;
+
+import edu.wpi.first.wpilibj.AddressableLED;
+import edu.wpi.first.wpilibj.AddressableLEDBuffer;
+import edu.wpi.first.wpilibj.AddressableLEDBufferView;
+import edu.wpi.first.wpilibj.LEDPattern;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+public class AddressableLEDSubsystem extends SubsystemBase {
+  private final AddressableLED led;
+  private final AddressableLEDBuffer ledBuffer;
+  private AddressableLEDBufferView ledViews[];
+
+  public AddressableLEDSubsystem() {
+    // Create strip and buffer
+    led = new AddressableLED(AddressableLEDConstants.LED_STRIP_PORT);
+    ledBuffer = new AddressableLEDBuffer(AddressableLEDConstants.LED_COUNT);
+    led.setLength(AddressableLEDConstants.LED_COUNT);
+
+    // Create section views
+    ledViews = new AddressableLEDBufferView[AddressableLEDConstants.SECTIONS.length];
+    for (int i = 0; i < ledViews.length; i++) {
+      ledViews[i] =
+          new AddressableLEDBufferView(
+              ledBuffer,
+              AddressableLEDConstants.SECTIONS[i].low,
+              AddressableLEDConstants.SECTIONS[i].high);
+    }
+  }
+
+  // Periodically update the LED strip
+  public void periodic() {
+    led.setData(ledBuffer);
+  }
+
+  // Apply a color pattern to a section of the LED strip
+  public void applySectionedPattern(LEDPattern pattern, int section) {
+    if (section < 0 || section >= ledViews.length) return;
+    pattern.applyTo(ledViews[section]);
+  }
+
+  // Apply a color pattern to a section of the LED strip
+  public void applyPattern(LEDPattern pattern) {
+    pattern.applyTo(ledBuffer);
+  }
+}


### PR DESCRIPTION
The original LED subsystem was based on `AddressableLED`, however it was migrated to a direct PWM controller after it was found that the original LED strips did not support the protocol used by WPILib and `AddressableLED`. A strip that supports `AddressableLED`'s protocol is now being added, hence this PR consisting of a slightly-updated version of the original LED subsystem implementation based on `AddressableLED`. The PWM-based LED controller should remain in-tree for now.